### PR TITLE
properly implemented AsReadonlySpan(), it gives a ReadOnlySpan<byte> object for further checks if needed, it uses the Array.AsSpan() method

### DIFF
--- a/Guid256.cs
+++ b/Guid256.cs
@@ -46,7 +46,7 @@ namespace Utils.Guid256
         #region Conversion
         public byte[] ToByteArray() => (byte[])_bytes.Clone();
 
-        public ReadOnlySpan<char> ToSpan() => Encoding.UTF8.GetString(_bytes.AsSpan());
+        public ReadOnlySpan<byte> AsReadOnlySpan() => _bytes.AsSpan();
 
         public static Guid256 Parse(string input)
         {

--- a/Utils.Guid256.XUnitTest/Guid256BaseUnitTest.cs
+++ b/Utils.Guid256.XUnitTest/Guid256BaseUnitTest.cs
@@ -140,5 +140,22 @@ namespace Utils.Guid256.XUnitTest
             Assert.Equal(hex4, resHex4);
             Assert.Equal(hex5, resHex5);
         }
+
+
+        [Fact]
+        public void AsReadonlySpan()
+        {
+            var guid = Guid256.NewGuid256();
+            var guidSpan = guid.AsReadOnlySpan();
+            var guidByteArray = guid.ToByteArray();
+
+            Assert.Equal(32, guidSpan.Length);
+            Assert.Equal(32, guidByteArray.Length);
+
+            for (int i = 0; i < 32; i++)
+            {
+                Assert.Equal(guidSpan[i], guidByteArray[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
properly implemented AsReadonlySpan(), it gives a ReadOnlySpan<byte> object for further checks if needed, it uses the Array.AsSpan() method